### PR TITLE
Bumps Harp

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.10.16"
   },
   "scripts": {
     "test": "grunt test"
@@ -46,6 +46,6 @@
     "harp", "grunt", "gruntplugin", "plugin"
   ],
   "dependencies": {
-    "harp": "~0.12.1"
+    "harp": "^0.14.0"
   }
 }


### PR DESCRIPTION
Bumps Harp, and mitigates this being necessary in the future before v1.0.0 by using `^` instead of `~`.
