### PR TITLE
Bump to latest version of harp

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "harp", "grunt", "gruntplugin", "plugin"
   ],
   "dependencies": {
-    "harp": "^0.15.0"
+    "harp": "^0.18.0"
   }
 }


### PR DESCRIPTION
The current version of harp locked in `grunt-harp` doesn't work with node v4.0.0. This PR fixed that!